### PR TITLE
add additional (breaking) tests for the loose flag

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -480,6 +480,28 @@ describe('VuePropTypes', () => {
       })).toBe(true)
     })
 
+    it('should validate an objects shape on `loose` mode and respect flags', () => {
+
+      const customType = VueTypes.shape(shape).loose.isRequired
+      expect(forceNoContext(customType.validator)({
+        id: 10,
+        name: 'John',
+        age: 30,
+        nationality: ''
+      })).toBe(true)
+    })
+
+    it('should validate an objects shape on `loose` mode and respect flags in different order', () => {
+
+      const customType = VueTypes.shape(shape).isRequired.loose
+      expect(forceNoContext(customType.validator)({
+        id: 10,
+        name: 'John',
+        age: 30,
+        nationality: ''
+      })).toBe(true)
+    })
+
     it('should NOT validate a value which is NOT an object', () => {
       const customType = VueTypes.shape(shape)
       const validator = forceNoContext(customType.validator)


### PR DESCRIPTION
In my understanding, the order of flags should not matter.
Added a test for `...loose.isRequired` and `....isRequired.loose`.

See #6 


It is totally ok, if you close this issue, right now the loose flag is only possible right after the `shape`.