### PR TITLE
README example update

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ export default {
       name: String,
       age: VueTypes.integer,
       id: VueTypes.integer.isRequired
-    }).def(() => { name: 'John' })
+    }).def(() => ({ name: 'John' })
   }
 }
 


### PR DESCRIPTION
Fixed a minor issue in the README where the example is wrong. It should return an object within braces.