### PR TITLE
First iteration: shim for production build

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,10 @@
 import isPlainObject from 'lodash/isPlainObject'
-import { noop, toType, getType, isFunction, validateType, isInteger, isArray, warn } from './utils'
+
+import * as utils from './utils'
+import * as shim from './shim'
+
+const { noop, toType, getType, isFunction, validateType, isInteger, isArray, warn }
+  = (process.env.NODE_ENV === 'production' ? shim : utils)
 
 const VueTypes = {
 

--- a/src/shim.js
+++ b/src/shim.js
@@ -1,0 +1,102 @@
+import isPlainObject from 'lodash/isPlainObject'
+
+/**
+ * No-op function
+ */
+export const noop = () => {}
+
+export const getType = () => true
+
+export const validateType = () => true
+
+/**
+ * Determines whether the passed value is an integer. Uses `Number.isInteger` if available
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
+ * @param {*} value - The value to be tested for being an integer.
+ * @returns {boolean}
+ */
+export const isInteger = Number.isInteger || function (value) {
+  return typeof value === 'number' && isFinite(value) && Math.floor(value) === value
+}
+
+/**
+ * Determines whether the passed value is an Array.
+ *
+ * @param {*} value - The value to be tested for being an array.
+ * @returns {boolean}
+ */
+export const isArray = Array.isArray || function (value) {
+  return toString.call(value) === '[object Array]'
+}
+
+/**
+ * Checks if a value is a function
+ *
+ * @param {any} value - Value to check
+ * @returns {boolean}
+ */
+export const isFunction = (value) => toString.call(value) === '[object Function]'
+
+const warn = noop
+
+export { warn }
+
+/**
+ * Adds a `def` method to the object returning a new object with passed in argument as `default` property
+ *
+ * @param {object} type - Object to enhance
+ */
+export const withDefault = function (type) {
+  Object.defineProperty(type, 'def', {
+    value(def) {
+      if (def === undefined && !this.default) {
+        return this
+      }
+      if (!isFunction(def) && !validateType(this, def)) {
+        console.log(`${this._vueTypes_name} - invalid default value: "${def}"`, def)
+        return this
+      }
+      if (isArray(def)) {
+        this.default = () => [...def]
+      } else if (isPlainObject(def)) {
+        this.default = () => Object.assign({}, def)
+      } else {
+        this.default = def
+      }
+      return this
+    },
+    enumerable: false,
+    writable: false
+  })
+}
+
+/**
+ * Adds a `isRequired` getter returning a new object with `required: true` key-value
+ *
+ * @param {object} type - Object to enhance
+ */
+export const withRequired = function (type) {
+  Object.defineProperty(type, 'isRequired', {
+    get() {
+      this.required = true
+      return this
+    },
+    enumerable: false
+  })
+}
+
+export const toType = (name, obj) => {
+  Object.defineProperty(obj, '_vueTypes_name', {
+    enumerable: false,
+    writable: false,
+    value: name
+  })
+  withRequired(obj)
+  withDefault(obj)
+
+  if (isFunction(obj.validator)) {
+    obj.validator = obj.validator.bind(obj)
+  }
+  return obj
+}

--- a/test/shim.test.js
+++ b/test/shim.test.js
@@ -1,0 +1,139 @@
+
+import expect from 'expect'
+import * as utils from '../src/shim'
+import {
+  stub_validateType,
+  reset_validateType,
+  stub_isFunction,
+  reset_isFunction
+} from '../src/utils'
+
+describe('`withDefault()` shim', () => {
+  let obj
+
+  beforeEach(() => {
+    obj = Object.create(null)
+  })
+
+  it('should set a `def` function as property on the target object', () => {
+    utils.withDefault(obj)
+    expect(obj.def).toBeA(Function)
+  })
+
+  it('`def` should NOT be enumerable', () => {
+    utils.withDefault(obj)
+    expect(Object.keys(obj)).toExclude('def')
+  })
+
+  it('`def` should NOT be writtable', () => {
+    utils.withDefault(obj)
+
+    expect(() => {
+      obj.def = 'demo'
+    }).toThrow()
+  })
+
+  describe('passed-in value', () => {
+    let validateSpy
+    let isFunctionSpy
+
+    beforeEach(() => {
+      validateSpy = expect.createSpy().andReturn(true)
+      isFunctionSpy = expect.createSpy().andReturn(false)
+      stub_validateType(validateSpy)
+      stub_isFunction(isFunctionSpy)
+    })
+    afterEach(() => {
+      reset_validateType()
+      reset_isFunction()
+    })
+
+    it('should check validity of passed-in value', () => {
+      const value = 'test'
+      utils.withDefault(obj)
+      obj.def(value)
+      expect(validateSpy).toHaveBeenCalledWith(obj, value)
+    })
+
+    it('skips validation if passed-in value is a function', () => {
+      isFunctionSpy.andReturn(true)
+      const value = 'test'
+      utils.withDefault(obj)
+      obj.def(value)
+      expect(isFunctionSpy).toHaveBeenCalledWith(value)
+      expect(validateSpy).toNotHaveBeenCalled()
+    })
+
+    it('exists if validation fails', () => {
+      validateSpy.andReturn(false)
+      utils.withDefault(obj)
+      obj.def(true)
+      expect(obj).toExcludeKey('default')
+    })
+
+    it('sets a `default` key on the object', () => {
+      utils.withDefault(obj)
+
+      const stubs = [true, null, 'string', () => { }, 0]
+
+      stubs.forEach((v) => {
+        obj.def(v)
+        expect(obj.default).toBe(v)
+      })
+    })
+
+    it('sets a factory function if value is an array', () => {
+      const arr = [0, 1]
+      utils.withDefault(obj)
+      obj.def(arr)
+      expect(obj.default).toBeA(Function)
+      expect(obj.default()).toNotBe(arr)
+      expect(obj.default()).toEqual(arr)
+    })
+
+    it('sets a factory function if value is an object', () => {
+      const value = { test: 'demo' }
+      utils.withDefault(obj)
+      obj.def(value)
+      expect(obj.default).toBeA(Function)
+      expect(obj.default()).toNotBe(value)
+      expect(obj.default()).toEqual(value)
+    })
+  })
+})
+
+describe('`toType()` shim', () => {
+  it('should enhance the passed-in object without cloning', () => {
+    const obj = {}
+
+    const type = utils.toType('testType', obj)
+    expect(type).toBe(obj)
+  })
+
+  it('should call `withRequired` on passed in object', () => {
+    const obj = {}
+
+    utils.toType('testType', obj)
+    expect(obj.hasOwnProperty('isRequired')).toBe(true)
+  })
+
+  it('should call `utils.withDefault` on passed in object', () => {
+    const obj = {}
+
+    utils.toType('testType', obj)
+    expect(obj.def).toBeA(Function)
+  })
+
+  it('should bind provided `validator function to the passed in object`', () => {
+    const obj = {
+      validator() {
+        return this
+      }
+    }
+
+    const type = utils.toType('testType', obj)
+    const validator = type.validator
+
+    expect(validator()).toBe(obj)
+  })
+})


### PR DESCRIPTION
The idea is to return the same functions of the original
utils.js file, but just return a simple implementation,
that mocks the original implementation but without
the validations.

### TODO

* [ ] some tests are still broken, I'm not sure why
* [ ] some methods were copied from `index.js` to `shim.js` and problaby have to just be imported.
* [ ] the tests from `shim.test.js` were copied from `index.test.js` and problaby need a way to be reused