### PR TITLE
Added Typescript casting support for `oneOfType`

### DIFF
--- a/src/validators/oneoftype.ts
+++ b/src/validators/oneoftype.ts
@@ -11,8 +11,9 @@ import {
 } from '../utils'
 
 export default function oneOfType<
-  U extends VueProp<any> | Prop<any>,
-  V = InferType<U>,
+  D extends InferType<U>,
+  U extends VueProp<any> | Prop<any> = any,
+  V = InferType<U> extends unknown ? U : InferType<U>,
 >(arr: U[]) {
   if (!isArray(arr)) {
     throw new TypeError(
@@ -52,13 +53,13 @@ export default function oneOfType<
   if (!hasCustomValidators) {
     // we got just native objects (ie: Array, Object)
     // delegate to Vue native prop check
-    return toType<V>('oneOfType', {
-      type: nativeChecks,
+    return toType<D>('oneOfType', {
+      type: nativeChecks as unknown as PropType<D>,
     })
   }
 
-  return toType<V>('oneOfType', {
-    type: nativeChecks,
+  return toType<D>('oneOfType', {
+    type: nativeChecks as unknown as PropType<D>,
     validator(value) {
       const err: string[] = []
       const valid = arr.some((type) => {

--- a/src/validators/oneoftype.ts
+++ b/src/validators/oneoftype.ts
@@ -10,10 +10,6 @@ import {
   indent,
 } from '../utils'
 
-type RawLocation = string | { name: string }
-const ctor = oneOfType([String, Object]) // Valid
-const route = oneOfType<RawLocation>([String, Object]) // Valid
-
 export default function oneOfType<
   D extends V,
   U extends VueProp<any> | Prop<any> = any,

--- a/src/validators/oneoftype.ts
+++ b/src/validators/oneoftype.ts
@@ -10,8 +10,12 @@ import {
   indent,
 } from '../utils'
 
+type RawLocation = string | { name: string }
+const ctor = oneOfType([String, Object]) // Valid
+const route = oneOfType<RawLocation>([String, Object]) // Valid
+
 export default function oneOfType<
-  D extends InferType<U>,
+  D extends V,
   U extends VueProp<any> | Prop<any> = any,
   V = InferType<U> extends unknown ? U : InferType<U>,
 >(arr: U[]) {


### PR DESCRIPTION
This PR is targeted for `oneOfType`.

## Problem before:

*Before vue-types*

```ts
props: {
   foo: { type: [String, Object] as PropType<RawLocation> }
}
```

*With vue-types ☹️*

![image](https://user-images.githubusercontent.com/15092120/125342467-40927f00-e355-11eb-9892-00604d16b939.png)

## With these changes, we can now cast the type we want and still have the default behaviour!

```ts
type RawLocation = string | { name: string }
const ctor = oneOfType([String, Object]) // Valid
const route = oneOfType<RawLocation>([String, Object]) // Valid
```

<img width="388" alt="Screenshot at Jul 12 21-00-15" src="https://user-images.githubusercontent.com/15092120/125342567-530cb880-e355-11eb-9980-627873bc331b.png">
<img width="475" alt="Screenshot at Jul 12 21-00-28" src="https://user-images.githubusercontent.com/15092120/125342571-53a54f00-e355-11eb-9b73-ca8ee6bb4057.png">

