### PR TITLE
oneOf support generics

### DIFF
--- a/docs/advanced/typescript.md
+++ b/docs/advanced/typescript.md
@@ -228,7 +228,7 @@ props: {
 
 ### oneOf
 
-This validator does not support type arguments, but you can use [const assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) on the expected values to constrain the validators type:
+You can use [const assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) on the expected values to constrain the validators type:
 
 ```ts
 props: {
@@ -237,3 +237,35 @@ props: {
   sizes: oneOf(['large', 'medium'] as const).def('small')
 }
 ```
+
+Alternative, you can pass a union type:
+
+```ts
+props: {
+  // Same (mostly) as above
+  // see below for details
+  sizes: oneOf<'large' | 'medium'>(['large', 'medium'])
+}
+```
+
+::: warning
+Note that union types don't put any constrain on the presence of all of their members in the validation array. This can lead to runtime bugs not detected by the type checker:
+
+```ts
+props: {
+  // type check allowed values: 'large' | 'medium' --> default OK
+  // runtime values: 'large' --> default ERROR
+  sizes: oneOf<'large' | 'medium'>(['large']).def('medium')
+}
+```
+
+As a general rule, we strongly suggest to use [const assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) whenever possible.
+
+```ts
+props: {
+  // type check and runtime error
+  sizes: oneOf(['large'] as const).def('medium')
+}
+```
+
+:::

--- a/examples/shared/default-namespace.ts
+++ b/examples/shared/default-namespace.ts
@@ -42,6 +42,12 @@ export const customTypeStrict =
 
 export const oneOf = VueTypes.oneOf([0, 'string', null]).def(2).isRequired
 
+export const oneOfUnion = VueTypes.oneOf<0 | 'string' | null>([
+  0,
+  'string',
+  null,
+]).def(0).isRequired
+
 export const oneOfStrict = VueTypes.oneOf([true, 'string'] as const).def(
   'string',
 ).isRequired
@@ -57,6 +63,14 @@ export const instanceOfType =
 instanceOfType.type = MyClass
 
 export const oneOfTypeType = VueTypes.oneOfType([
+  String,
+  {
+    type: String,
+  },
+  VueTypes.number,
+])
+
+export const oneOfTypeTSType = VueTypes.oneOfType<string | number>([
   String,
   {
     type: String,

--- a/examples/shared/validators.ts
+++ b/examples/shared/validators.ts
@@ -88,6 +88,14 @@ export const tupleType = custom<Pair>(
  * `oneOf` validator examples
  */
 export const oneOfTuple = oneOf([1, 2, 'string'] as const).def(1)
+
+export const oneOfUnion = oneOf<1 | 2 | 'string'>([1, 2, 'string']).def(1)
+export const oneOfTupleUnion = oneOf<1 | 2 | 'string'>([
+  1,
+  'string',
+] as const).def(2)
+export const oneOfArray = oneOf([1, 2, 'string']).def(1)
+
 interface OneUser {
   name: string
 }

--- a/src/validators/oneof.ts
+++ b/src/validators/oneof.ts
@@ -1,7 +1,9 @@
 import { Prop } from '../types'
 import { toType, warn, isArray } from '../utils'
 
-export default function oneOf<T extends readonly any[]>(arr: T) {
+export default function oneOf<D, T extends readonly D[] = readonly D[]>(
+  arr: T,
+) {
   if (!isArray(arr)) {
     throw new TypeError(
       '[VueTypes error]: You must provide an array as argument.',


### PR DESCRIPTION
This PR adds support for type arguments to the `oneOf` validator:

```ts
type Genre = 'action' | 'thriller'

props: {
  genre: oneOf<Genre>(['action', 'thriller'])
}
```