### PR TITLE
Review shim DX

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+shim

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ Icon
 .Spotlight-V100
 .Trashes
 dist
+shim/*.*
+!shim/package.json

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -25,11 +25,15 @@ Add the following script tags before your code
 
 Starting from version 4, VueTypes is published as a **native ESM module** with CommonJS and UMD support.
 
-Modern bundlers and tools should be able to automatically pick the correct version based on your configuration.
+Modern bundlers and tools should be able to automatically pick the correct entry point based on your configuration.
 
-::: tip NOTE
+```js
+import { string, oneOf } from 'vue-types' // or: import VueTypes from 'vue-types';
+```
 
-Here is the list of available entry points:
+::: details More details
+
+For reference, here is the list of available entry points:
 
 - `vue-types.modern.js`: ES module for environments [supporting it](https://caniuse.com/es6-module). This is the default entry point for Node 14+, Webpack 5+, Rollup and other tools with native support for ES Modules (like [Vite](https://vitejs.dev/), Vue CLI 5 and [Snowpack](https://www.snowpack.dev/)).
 - `vue-types.m.js`: ES5 compiled version exported as ES module. This is the default entry point for Webpack 4 and frameworks like [Nuxt 2](https://nuxtjs.org/) and [Vue CLI 4](https://cli.vuejs.org/)
@@ -40,13 +44,15 @@ Here is the list of available entry points:
 
 ## Production build
 
-Vue.js does not validate components' props when used in a production build. If you're using a bundler such as Webpack or rollup you can shrink VueTypes file size by around **70%** (minified and gzipped) by removing the validation logic while preserving the library's API methods. To achieve that result, VueTypes ships with a `vue-types/shim` module that can be used as alias in the production build.
+If you're using a bundler such as Webpack or rollup, you can shrink VueTypes file size by around **70%** (minified and gzipped) by removing the validation logic while preserving the library's API methods. To achieve that result, VueTypes ships with a `vue-types/shim` module that can be used as alias in production builds.
 
-By aliasing `vue-types` to `vue-types/shim`, bundlers should be able to pick the module type that fits your configuration (ES, CommonJS, ...).
+By just aliasing `vue-types` to `vue-types/shim`, bundlers should be able to pick the module type that fits your configuration (ES, CommonJS, ...).
 
-::: tip NOTE
+See below for common configuration scenarios.
 
-As an additional insight, here is a table showing the full and shim versions of the library for each module system.
+::: details More details
+
+For reference, here is a table showing the full and shim versions of the library for each module system.
 
 | Module system | Full Library entry point | Shim entry point       |
 | ------------- | ------------------------ | ---------------------- |
@@ -132,7 +138,55 @@ return {
 }
 ```
 
-Note: If you are using [@rollup/plugin-node-resolve](https://www.npmjs.com/package/@rollup/plugin-node-resolve) make sure to place the alias plugin **before** the resolve plugin.
+::: warning
+If you are using [@rollup/plugin-node-resolve](https://www.npmjs.com/package/@rollup/plugin-node-resolve) make sure to place the alias plugin **before** the resolve plugin.
+
+:::
+
+### NuxtJS
+
+VueTypes provides a NuxtJS module that will automatically enable the shim for production builds:
+
+```js
+// nuxt.config.js
+
+export default {
+  // ...
+  modules: ['vue-types/nuxt'],
+}
+```
+
+The modules accepts a `shim` boolean option to forcefully enable / disable the shim:
+
+```js
+// nuxt.config.js
+
+export default {
+  // ...
+  // use the shim even during development
+  modules: [['vue-types/nuxt', { shim: true }]],
+}
+```
+
+::: tip
+You can configure NuxtJS manually using the `build.extend` method:
+
+```js
+// nuxt.config.js
+
+export default {
+  // ...
+  build: {
+    extend(config, ctx) {
+      if (ctx.isDev) {
+        config.resolve.alias['vue-types'] = 'vue-types/shim'
+      }
+    },
+  },
+}
+```
+
+:::
 
 ### Vite
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -44,7 +44,7 @@ For reference, here is the list of available entry points:
 
 ## Production build
 
-If you're using a bundler such as Webpack or rollup, you can shrink VueTypes file size by around **70%** (minified and gzipped) by removing the validation logic while preserving the library's API methods. To achieve that result, VueTypes ships with a `vue-types/shim` module that can be used as alias in production builds.
+Vue.js does not validate components' props when used in a production build. If you're using a bundler such as Webpack or rollup, you can shrink VueTypes file size by around **70%** (minified and gzipped) by removing the validation logic while preserving the library's API methods. To achieve that result, VueTypes ships with a `vue-types/shim` module that can be used as alias in production builds.
 
 By just aliasing `vue-types` to `vue-types/shim`, bundlers should be able to pick the module type that fits your configuration (ES, CommonJS, ...).
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -23,41 +23,53 @@ Add the following script tags before your code
 
 ## Usage with bundlers
 
-Starting from version 4, VueTypes is published as a native ESM module with CommonJS and UMD support.
+Starting from version 4, VueTypes is published as a **native ESM module** with CommonJS and UMD support.
 
 Modern bundlers and tools should be able to automatically pick the correct version based on your configuration.
 
-Anyway, here is the list of available entry points:
+::: tip NOTE
+
+Here is the list of available entry points:
 
 - `vue-types.modern.js`: ES module for environments [supporting it](https://caniuse.com/es6-module). This is the default entry point for Node 14+, Webpack 5+, Rollup and other tools with native support for ES Modules (like [Vite](https://vitejs.dev/), Vue CLI 5 and [Snowpack](https://www.snowpack.dev/)).
 - `vue-types.m.js`: ES5 compiled version exported as ES module. This is the default entry point for Webpack 4 and frameworks like [Nuxt 2](https://nuxtjs.org/) and [Vue CLI 4](https://cli.vuejs.org/)
 - `vue-types.cjs`: ES5 compiled version exported as CommonJS module. This is the default entry point for Node 12 and older and tools not supporting ES Modules.
 - `vue-types.umd.js`: ES5 compiled version bundled as UMD module. This entry point can be used when loading VueTypes from a `<script src="...">` tag or from a CDN. It's the default entry point for [unpkg](https://unpkg.com/).
 
+:::
+
 ## Production build
 
-Vue.js does not validate components' props when used in a production build. If you're using a bundler such as Webpack or rollup you can shrink VueTypes file size by around **70%** (minified and gzipped) by removing the validation logic while preserving the library's API methods. To achieve that result, VueTypes ships with a `shim` module that can be used as alias in the production build.
+Vue.js does not validate components' props when used in a production build. If you're using a bundler such as Webpack or rollup you can shrink VueTypes file size by around **70%** (minified and gzipped) by removing the validation logic while preserving the library's API methods. To achieve that result, VueTypes ships with a `vue-types/shim` module that can be used as alias in the production build.
 
-| Full Library entry point | Shim entry point |
-| ------------------------ | ---------------- |
-| `vue-types.modern.js`    | `shim.modern.js` |
-| `vue-types.m.js`         | `shim.m.js`      |
-| `vue-types.cjs`          | `shim.cjs`       |
-| `vue-types.umd.js`       | `shim.umd.js`    |
+By aliasing `vue-types` to `vue-types/shim`, bundlers should be able to pick the module type that fits your configuration (ES, CommonJS, ...).
+
+::: tip NOTE
+
+As an additional insight, here is a table showing the full and shim versions of the library for each module system.
+
+| Module system | Full Library entry point | Shim entry point       |
+| ------------- | ------------------------ | ---------------------- |
+| Modern ES     | `vue-types.modern.js`    | `shim/index.modern.js` |
+| ES5 ES        | `vue-types.m.js`         | `shim/index.m.js`      |
+| CommonJS      | `vue-types.cjs`          | `shim/index.cjs.js`    |
+| UMD           | `vue-types.umd.js`       | `shim/index.umd.js`    |
+
+:::
 
 ### CDN usage
 
 If you're including the library via a `script` tag, use the dedicated shim build file:
 
 ```html
-<script src="https://unpkg.com/vue-types@latest/dist/shim.umd.js"></script>
+<script src="https://unpkg.com/vue-types@latest/shim/index.umd.js"></script>
 ```
 
 **Note:** In order to use a specific version of the library change `@latest` with `@<version-number>`:
 
 ```html
-<!-- use the shim from version 2.0.0 -->
-<script src="https://unpkg.com/vue-types@2.0.0/dist/shim.umd.js"></script>
+<!-- use the shim from version 4.1.0 -->
+<script src="https://unpkg.com/vue-types@4.1.0/shim/index.umd.js"></script>
 ```
 
 ### Webpack 4 and earlier
@@ -73,7 +85,7 @@ return {
     alias: {
       // ... other aliases
       ...(process.env.NODE_ENV === 'production' && {
-        'vue-types': require.resolve('vue-types/dist/shim.m.js'),
+        'vue-types': 'vue-types/shim',
       }),
     },
   },

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -18,7 +18,25 @@ npm install vue-types --save
 Add the following script tags before your code
 
 ```html
-<script src="https://unpkg.com/vue-types"></script>
+<script src="https://unpkg.com/vue-types@4"></script>
+
+<!-- Or -->
+
+<script src="https://cdn.jsdelivr.net/npm/vue-types@4/dist/vue-types.umd.js"></script>
+```
+
+In modern browsers [supporting ES Modules](https://caniuse.com/es6-module) you can import the library like this:
+
+```html
+<script type="module">
+  import { string, number } from 'https://unpkg.com/vue-types@4?module'
+</script>
+
+<!-- Or -->
+
+<script type="module">
+  import { string, number } from 'https://cdn.jsdelivr.net/npm/vue-types@4/+esm'
+</script>
 ```
 
 ## Usage with bundlers
@@ -68,17 +86,10 @@ For reference, here is a table showing the full and shim versions of the library
 If you're including the library via a `script` tag, use the dedicated shim build file:
 
 ```html
-<script src="https://unpkg.com/vue-types@latest/shim/index.umd.js"></script>
+<script src="https://unpkg.com/vue-types@4/shim/index.umd.js"></script>
 ```
 
-**Note:** In order to use a specific version of the library change `@latest` with `@<version-number>`:
-
-```html
-<!-- use the shim from version 4.1.0 -->
-<script src="https://unpkg.com/vue-types@4.1.0/shim/index.umd.js"></script>
-```
-
-### Webpack 4 and earlier
+### Webpack
 
 The following example will shim the module in Webpack by adding an [alias field](https://webpack.js.org/configuration/resolve/#resolve-alias) to the configuration when `NODE_ENV` is set to `"production"`:
 
@@ -93,25 +104,6 @@ return {
       ...(process.env.NODE_ENV === 'production' && {
         'vue-types': 'vue-types/shim',
       }),
-    },
-  },
-}
-```
-
-### Webpack 5
-
-The following example will shim the module in Webpack by adding an [alias field](https://webpack.js.org/configuration/resolve/#resolve-alias) to the configuration when `NODE_ENV` is set to `"production"`:
-
-```js
-// webpack.config.js
-
-return {
-  // ... configuration
-  resolve: {
-    alias: {
-      // ... other aliases
-      'vue-types': 'vue-types/shim',
-      },
     },
   },
 }

--- a/nuxt/module.js
+++ b/nuxt/module.js
@@ -1,0 +1,30 @@
+/* global module, require */
+
+/**
+ * @typedef {Object} ModuleOptions
+ *
+ * @property {boolean} [shim]
+ */
+
+/**
+ * @type {import('@nuxt/types').Module}
+ * @param {ModuleOptions} moduleOptions
+ */
+module.exports = function VueTypesModule(moduleOptions = {}) {
+  this.extendBuild(function (config, ctx) {
+    if (
+      (ctx.isDev && moduleOptions.shim !== true) ||
+      moduleOptions.shim === false
+    ) {
+      return
+    }
+    if (!config.resolve) {
+      config.resolve = {}
+    }
+    config.resolve.alias = Object.assign(config.resolve.alias || {}, {
+      'vue-types': 'vue-types/shim',
+    })
+  })
+}
+
+module.exports.meta = require('./package.json')

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "vue-types-nuxt",
+  "version": "1.0.0",
+  "main": "module.js"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-types",
-  "version": "4.0.1",
+  "version": "4.1.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2405,6 +2405,41 @@
         "fastq": "^1.6.0"
       }
     },
+    "@nuxt/types": {
+      "version": "2.15.7",
+      "resolved": "https://registry.npmjs.org/@nuxt/types/-/types-2.15.7.tgz",
+      "integrity": "sha512-jqExebL4Dh5Rn88xVP1/o/a4gxpF7Z1O/kbVjEzEbbvt2E8J0lLc3wsaRYpbqt+S3S9YfvD8FKR85TzkqYtgqw==",
+      "dev": true,
+      "requires": {
+        "@types/autoprefixer": "9.7.2",
+        "@types/babel__core": "7.1.14",
+        "@types/compression": "1.7.0",
+        "@types/connect": "3.4.34",
+        "@types/etag": "1.8.0",
+        "@types/file-loader": "5.0.0",
+        "@types/html-minifier": "4.0.0",
+        "@types/less": "3.0.2",
+        "@types/node": "12.20.12",
+        "@types/optimize-css-assets-webpack-plugin": "5.0.3",
+        "@types/pug": "2.0.4",
+        "@types/sass-loader": "8.0.1",
+        "@types/serve-static": "1.13.9",
+        "@types/terser-webpack-plugin": "4.2.1",
+        "@types/webpack": "4.41.28",
+        "@types/webpack-bundle-analyzer": "3.9.3",
+        "@types/webpack-dev-middleware": "4.1.2",
+        "@types/webpack-hot-middleware": "2.25.4",
+        "sass-loader": "10.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.12.tgz",
+          "integrity": "sha512-KQZ1al2hKOONAs2MFv+yTQP1LkDWMrRJ9YCVRalXltOfXsBmH5IownLxQaiq0lnAHwAViLnh2aTYqrPcRGEbgg==",
+          "dev": true
+        }
+      }
+    },
     "@rollup/plugin-alias": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.2.tgz",
@@ -2505,6 +2540,99 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/anymatch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-3.0.0.tgz",
+      "integrity": "sha512-qLChUo6yhpQ9k905NwL74GU7TxH+9UODwwQ6ICNI+O6EDMExqH/Cv9NsbmcZ7yC/rRXJ/AHCzfgjsFRY5fKjYw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "*"
+      }
+    },
+    "@types/autoprefixer": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@types/autoprefixer/-/autoprefixer-9.7.2.tgz",
+      "integrity": "sha512-QX7U7YW3zX3ex6MECtWO9folTGsXeP4b8bSjTq3I1ODM+H+sFHwGKuof+T+qBcDClGlCGtDb3SVfiTVfmcxw4g==",
+      "dev": true,
+      "requires": {
+        "@types/browserslist": "*",
+        "postcss": "7.x.x"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.36",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
+          "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.14",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
@@ -2546,11 +2674,107 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/browserslist": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@types/browserslist/-/browserslist-4.15.0.tgz",
+      "integrity": "sha512-h9LyKErRGZqMsHh9bd+FE8yCIal4S0DxKTOeui56VgVXqa66TKiuaIUxCAI7c1O0LjaUzOTcsMyOpO9GetozRA==",
+      "dev": true,
+      "requires": {
+        "browserslist": "*"
+      }
+    },
+    "@types/clean-css": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.5.tgz",
+      "integrity": "sha512-NEzjkGGpbs9S9fgC4abuBvTpVwE3i+Acu9BBod3PUyjDVZcNsGx61b8r2PphR61QGPnn0JHVs5ey6/I4eTrkxw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@types/compression": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.7.0.tgz",
+      "integrity": "sha512-3LzWUM+3k3XdWOUk/RO+uSjv7YWOatYq2QADJntK1pjkk4DfVP0KrIEPDnXRJxAAGKe0VpIPRmlINLDuCedZWw==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "@types/etag": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@types/etag/-/etag-1.8.0.tgz",
+      "integrity": "sha512-EdSN0x+Y0/lBv7YAb8IU4Jgm6DWM+Bqtz7o5qozl96fzaqdqbdfHS5qjdpFeIv7xQ8jSLyjMMNShgYtMajEHyQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/file-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/file-loader/-/file-loader-5.0.0.tgz",
+      "integrity": "sha512-evodFzM0PLOXmMZy8DhPN+toP6QgJiIteF6e8iD9T0xGBUllQA/DAb1nZwCIoNh7vuLvqCGPUdsLf3GSbcHd4g==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "^4"
+      }
     },
     "@types/glob": {
       "version": "7.1.3",
@@ -2569,6 +2793,17 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/html-minifier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-4.0.0.tgz",
+      "integrity": "sha512-eFnGhrKmjWBlnSGNtunetE3UU2Tc/LUl92htFslSSTmpp9EKHQVcYQadCyYfnzUEFB5G/3wLWo/USQS/mEPKrA==",
+      "dev": true,
+      "requires": {
+        "@types/clean-css": "*",
+        "@types/relateurl": "*",
+        "@types/uglify-js": "*"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -2711,6 +2946,18 @@
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
+    "@types/less": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/less/-/less-3.0.2.tgz",
+      "integrity": "sha512-62vfe65cMSzYaWmpmhqCMMNl0khen89w57mByPi1OseGfcV/LV03fO8YVrNj7rFQsRWNJo650WWyh6m7p8vZmA==",
+      "dev": true
+    },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
@@ -2729,11 +2976,29 @@
       "integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==",
       "dev": true
     },
+    "@types/node-sass": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node-sass/-/node-sass-4.11.2.tgz",
+      "integrity": "sha512-pOFlTw/OtZda4e+yMjq6/QYuvY0RDMQ+mxXdWj7rfSyf18V8hS4SfgurO+MasAkQsv6Wt6edOGlwh5QqJml9gw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
+    },
+    "@types/optimize-css-assets-webpack-plugin": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
+      "integrity": "sha512-PJgbI4KplJfyxKWVrBbEL+rePEBqeozJRMT0mBL3ynhvngASBV/XJ+BneLuJN74RjjMzO0gA5ns80mgubQdZAA==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "^4"
+      }
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -2747,10 +3012,34 @@
       "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
       "dev": true
     },
+    "@types/pug": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.4.tgz",
+      "integrity": "sha1-h3L80EGOPNLMFxVV1zAHQVBR9LI=",
+      "dev": true
+    },
     "@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
+      "dev": true
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "@types/relateurl": {
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.29.tgz",
+      "integrity": "sha512-QSvevZ+IRww2ldtfv1QskYsqVVVwCKQf1XbwtcyyoRvLIQzfyPhj/C+3+PKzSDRdiyejaiLgnq//XTkleorpLg==",
       "dev": true
     },
     "@types/resolve": {
@@ -2762,11 +3051,169 @@
         "@types/node": "*"
       }
     },
+    "@types/sass": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.16.1.tgz",
+      "integrity": "sha512-iZUcRrGuz/Tbg3loODpW7vrQJkUtpY2fFSf4ELqqkApcS2TkZ1msk7ie8iZPB86lDOP8QOTTmuvWjc5S0R9OjQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/sass-loader": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sass-loader/-/sass-loader-8.0.1.tgz",
+      "integrity": "sha512-kum0/5Im5K2WdDTRsLtrXXvX2VJc3rgq9favK+vIdWLn35miWUIYuPkiQlLCHks9//sZ3GWYs4uYzCdmoKKLcQ==",
+      "dev": true,
+      "requires": {
+        "@types/node-sass": "*",
+        "@types/sass": "*",
+        "@types/webpack": "^4"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
+      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/source-list-map": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+      "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
       "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
+    },
+    "@types/tapable": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
+      "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
+      "dev": true
+    },
+    "@types/terser-webpack-plugin": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/terser-webpack-plugin/-/terser-webpack-plugin-4.2.1.tgz",
+      "integrity": "sha512-x688KsgQKJF8PPfv4qSvHQztdZNHLlWJdolN9/ptAGimHVy3rY+vHdfglQDFh1Z39h7eMWOd6fQ7ke3PKQcdyA==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "^4",
+        "terser": "^4.6.13"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "terser": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
+        }
+      }
+    },
+    "@types/uglify-js": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
+      "integrity": "sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@types/webpack": {
+      "version": "4.41.28",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.28.tgz",
+      "integrity": "sha512-Nn84RAiJjKRfPFFCVR8LC4ueTtTdfWAMZ03THIzZWRJB+rX24BD3LqPSFnbMscWauEsT4segAsylPDIaZyZyLQ==",
+      "dev": true,
+      "requires": {
+        "@types/anymatch": "*",
+        "@types/node": "*",
+        "@types/tapable": "^1",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@types/webpack-bundle-analyzer": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@types/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.3.tgz",
+      "integrity": "sha512-l/vaDMWGcXiMB3CbczpyICivLTB07/JNtn1xebsRXE9tPaUDEHgX3x7YP6jfznG5TOu7I4w0Qx1tZz61znmPmg==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "^4"
+      }
+    },
+    "@types/webpack-dev-middleware": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/webpack-dev-middleware/-/webpack-dev-middleware-4.1.2.tgz",
+      "integrity": "sha512-SxXzPCqeZ03fJ2dg3iD7cSXvqZymmS5/2GD9fANRcyWN7HYK1H3ty6q7IInXZKvPrdUqij831G3RLIeKK6aGdw==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/webpack": "^4"
+      }
+    },
+    "@types/webpack-hot-middleware": {
+      "version": "2.25.4",
+      "resolved": "https://registry.npmjs.org/@types/webpack-hot-middleware/-/webpack-hot-middleware-2.25.4.tgz",
+      "integrity": "sha512-6tQb9EBKIANZYUVLQYWiWfDFVe7FhXSj4bB2EF5QB7VtYWL3HDR+y/zqjZPAnCorv0spLqVMRqjRK8AmhfocMw==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/webpack": "^4"
+      }
+    },
+    "@types/webpack-sources": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.1.1.tgz",
+      "integrity": "sha512-MjM1R6iuw8XaVbtkCBz0N349cyqBjJHCbQiOeppe3VBeFvxqs74RKHAVt9LkxTnUWc7YLZOEsUfPUnmK6SBPKQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
     },
     "@types/yargs": {
       "version": "16.0.3",
@@ -13101,6 +13548,12 @@
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
       "dev": true
     },
+    "klona": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
+      "dev": true
+    },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
@@ -18844,6 +19297,49 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sass-loader": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.1.1.tgz",
+      "integrity": "sha512-W6gVDXAd5hR/WHsPicvZdjAWHBcEJ44UahgxcIE196fW2ong0ZHMPO1kZuI5q0VlvMQZh32gpv69PLWQm70qrw==",
+      "dev": true,
+      "requires": {
+        "klona": "^2.0.4",
+        "loader-utils": "^2.0.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.0.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.8",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+          "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
     },
     "sax": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-types",
-  "version": "4.1.0-beta.2",
+  "version": "4.1.0-beta.3",
   "description": "Prop types utility for Vue",
   "author": "Marco Solazzi",
   "license": "MIT",
@@ -22,8 +22,8 @@
       "import": "./dist/vue-types.modern.js"
     },
     "./shim": {
-      "require": "./dist/shim.cjs",
-      "import": "./dist/shim.modern.js"
+      "require": "./shim/index.cjs.js",
+      "import": "./shim/index.modern.js"
     }
   },
   "types": "dist/index.d.ts",
@@ -32,18 +32,22 @@
   },
   "files": [
     "dist",
+    "shim",
     "src",
     "types/*.d.ts"
   ],
   "scripts": {
-    "prepublishOnly": "run-s lint lint:examples test build",
-    "build": "run-s build:clean build:copy build:cjs build:shim:cjs build:ts build:umd",
-    "build:clean": "del dist",
-    "build:copy": "cpy src/*.d.ts dist",
-    "build:ts": "microbundle --external=vue --tsconfig=./tsconfig.build.json --format=modern,es",
-    "build:cjs": "microbundle --external=vue --tsconfig=./tsconfig.build.json -i src/index.cjs.ts -o dist/vue-types.cjs --no-pkg-main --format=cjs",
-    "build:shim:cjs": "microbundle --external=vue --tsconfig=./tsconfig.build.json -i src/shim.cjs.ts -o dist/shim.cjs --no-pkg-main --format=cjs",
-    "build:umd": "cross-env NODE_ENV=production microbundle --external=vue --tsconfig=./tsconfig.build.json --format=umd",
+    "prepublishOnly": "run-s lint lint:ts test build",
+    "build": "run-s 'clean:*' copy 'build:**'",
+    "clean:dist": "del dist",
+    "clean:shim": "del \"shim/*.*\" \"!shim/package.json\"",
+    "copy": "cpy src/*.d.ts dist",
+    "build:ts": "microbundle --tsconfig=./tsconfig.build.json --format=modern,es",
+    "build:cjs": "microbundle --tsconfig=./tsconfig.build.json -i src/index.cjs.ts -o dist/vue-types.cjs --no-pkg-main --format=cjs",
+    "build:umd": "cross-env NODE_ENV=production microbundle --tsconfig=./tsconfig.build.json --format=umd",
+    "build:shim:ts": "microbundle --tsconfig=./tsconfig.build.json -i src/shim.ts -o shim/index.js --format=modern,es --no-sourcemap",
+    "build:shim:cjs": "microbundle --tsconfig=./tsconfig.build.json -i src/shim.cjs.ts -o shim/index.cjs.js --no-pkg-main --format=cjs --no-sourcemap",
+    "build:shim:umd": "cross-env NODE_ENV=production microbundle --tsconfig=./tsconfig.build.json -i src/shim.cjs.ts -o shim/index.js --format=umd --no-sourcemap",
     "test": "jest",
     "lint": "run-s lint:*",
     "lint:ts": "tsc --noEmit -p ./examples",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "./shim": {
       "require": "./shim/index.cjs.js",
       "import": "./shim/index.modern.js"
-    }
+    },
+    "./nuxt": "./nuxt/module.js"
   },
   "types": "dist/index.d.ts",
   "engines": {
@@ -71,6 +72,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "7.14.5",
     "@babel/plugin-proposal-optional-chaining": "7.14.5",
+    "@nuxt/types": "2.15.7",
     "@types/jest": "26.0.24",
     "@types/node": "14.17.5",
     "@typescript-eslint/eslint-plugin": "4.28.5",

--- a/shim/package.json
+++ b/shim/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "vue-types-shim",
+  "main": "index.cjs.js",
+  "unpkg": "index.umd.js",
+  "umd:main": "index.umd.js",
+  "module": "index.m.js",
+  "esmodule": "index.modern.js",
+  "types": "../dist/shim.d.ts",
+  "peerDependencies": {
+    "vue": "^2.0.0 || ^3.0.0"
+  },
+  "dependencies": {
+    "is-plain-object": "5.0.0"
+  }
+}


### PR DESCRIPTION
Closes #152 

### 1) Build the shim module inside a `vue-types/shim` folder 

Inside `vue-types/shim` we store ES, modern, UMD, and CJS builds. The folder also contains a custom `package.json` as a CJS sub-module. with the list of entry points for the various module systems (except the `exports` key).
 
In this way, module systems that don't support native ES Module will be able to `vue-types/shim` to the correct entry point.

Modules supporting native ES Module will read the `exports` mapping in the root `package.json` and resolve to the modern build of the shim.

The user now only has to alias `vue-types` to `vue-types/shim`. This is the best option to simplify the DX and fully delegate the module resolution to bundlers and module systems.

### 2) Old shim build location is preserved for compatibility 

Because this might be a breaking change, we still bundle the shim inside the `dist` folder to support old configurations.

### 3) add `vue-types/nuxt`

`vue-types/nuxt` is a NuxtJS module that automatically enables the shim for production builds. it also takes a `shim` boolean option to forcefully enable or disable the shim for all builds. 