### PR TITLE
Fix: force execution of custom validator function in validateType

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -122,6 +122,19 @@ describe('`validateType()`', () => {
       utils.validateType({ type: String, required: true }, undefined),
     ).toBe(false)
   })
+
+  it('should validate validators with no type or type === true', () => {
+    expect(utils.validateType({}, 'anyValue')).toBe(true)
+    expect(utils.validateType({ type: true }, 'anyValue')).toBe(true)
+  })
+
+  it('should execute the validator for type === null', () => {
+    const validator = jest.fn().mockReturnValue(false)
+    expect(utils.validateType({ type: null, validator }, 'anyValue')).toBe(
+      false,
+    )
+    expect(validator).toHaveBeenLastCalledWith('anyValue')
+  })
 })
 
 describe('`toType()`', () => {

--- a/__tests__/validators/custom.test.ts
+++ b/__tests__/validators/custom.test.ts
@@ -1,4 +1,5 @@
 import custom from '../../src/validators/custom'
+import { validateType } from '../../src/utils'
 import { VueTypeDef } from '../../src/types'
 import { forceNoContext, checkRequired } from '../helpers'
 
@@ -12,6 +13,7 @@ describe('`.custom`', () => {
   it('should match an object with a validator method', () => {
     expect(customType).toEqual(
       expect.objectContaining({
+        type: null,
         validator: expect.any(Function),
       }),
     )
@@ -29,5 +31,12 @@ describe('`.custom`', () => {
     const validator = forceNoContext(customType.validator)
     expect(validator('mytest')).toBe(true)
     expect(validator(0)).toBe(false)
+  })
+
+  it('should trigger the validator in validateType', () => {
+    const spy = jest.fn().mockReturnValue(true)
+    const type = custom(spy)
+    expect(validateType(type, '__TEST__')).toBe(true)
+    expect(spy).toHaveBeenCalledWith('__TEST__')
   })
 })

--- a/src/validators/custom.ts
+++ b/src/validators/custom.ts
@@ -12,7 +12,7 @@ export default function custom<T>(
   }
 
   return toType<T>(validatorFn.name || '<<anonymous function>>', {
-    type: null as PropType<T>,
+    type: null as unknown as PropType<T>,
     validator(this: VueTypeDef<T>, value: T) {
       const valid = validatorFn(value)
       if (!valid) warn(`${this._vueTypes_name} - ${warnMsg}`)

--- a/src/validators/custom.ts
+++ b/src/validators/custom.ts
@@ -1,5 +1,5 @@
 import { toType, warn } from '../utils'
-import { ValidatorFunction, VueTypeDef } from '../types'
+import { ValidatorFunction, VueTypeDef, PropType } from '../types'
 
 export default function custom<T>(
   validatorFn: ValidatorFunction<T>,
@@ -12,6 +12,7 @@ export default function custom<T>(
   }
 
   return toType<T>(validatorFn.name || '<<anonymous function>>', {
+    type: null as PropType<T>,
     validator(this: VueTypeDef<T>, value: T) {
       const valid = validatorFn(value)
       if (!valid) warn(`${this._vueTypes_name} - ${warnMsg}`)


### PR DESCRIPTION
This PR should fix #176. 

Currently `validateType` does not execute the `type.validator` function when `type.type` is `undefined` or `true`. 

To force validators created with `custom()` to be validated we set their type to `null`.  