### PR TITLE
Fix: oneOfType native check resolution

### DIFF
--- a/__tests__/validators/oneoftype.test.ts
+++ b/__tests__/validators/oneoftype.test.ts
@@ -45,6 +45,11 @@ describe('`.oneOfType`', () => {
     expect(validator({ id: '10' })).toBe(false)
   })
 
+  it('should extract native types from other validators', () => {
+    const type = oneOfType([string(), integer()])
+    expect(type.type).toEqual([String, Number])
+  })
+
   it('should validate multiple shapes', () => {
     const customType = oneOfType([
       shape({

--- a/src/validators/oneoftype.ts
+++ b/src/validators/oneoftype.ts
@@ -42,12 +42,12 @@ export default function oneOfType<
       if (type.type === true || !type.type) {
         warn('oneOfType - invalid usage of "true" or "null" as types.')
         continue
-      }
-      if (type.type) {
+      } else {
         nativeChecks = nativeChecks.concat(type.type)
       }
+    } else {
+      nativeChecks.push(type as Prop<V>)
     }
-    nativeChecks.push(type as Prop<V>)
   }
 
   // filter duplicates


### PR DESCRIPTION
This PR fixes a bug introduced in 68110795861a9cfd9cede3a9005d910c10b4373f that causes the `nativeChecks` array to contain instances of validators in the following scenario:

```ts
oneOfType([number(), string()])
```
**Expected**
![image](https://user-images.githubusercontent.com/104721/136187597-4ae0c2c0-ba73-4c68-8e3c-5a3f759337bd.png)

**Result**
![image](https://user-images.githubusercontent.com/104721/136187541-e0509578-35ff-42bd-ba2a-aed1e77f9cf6.png)