### PR TITLE
Fix the management of null props

### DIFF
--- a/.changeset/fair-gifts-serve.md
+++ b/.changeset/fair-gifts-serve.md
@@ -1,0 +1,8 @@
+---
+'vue-types': patch
+---
+
+- Accepts null as valid value in validateType util
+- fix docs: `nullable()` should be used for nullable required props.
+
+Closes #383

--- a/packages/core/__tests__/utils.test.ts
+++ b/packages/core/__tests__/utils.test.ts
@@ -123,6 +123,9 @@ describe('`validateType()`', () => {
   it('should allow undefined explicit values for non-required types', () => {
     expect(utils.validateType({ type: String }, undefined)).toBe(true)
   })
+  it('should allow null explicit values for non-required types', () => {
+    expect(utils.validateType({ type: String }, null)).toBe(true)
+  })
   it('should NOT allow undefined explicit values for required types', () => {
     expect(
       utils.validateType({ type: String, required: true }, undefined),

--- a/packages/core/__tests__/validators/oneoftype.test.ts
+++ b/packages/core/__tests__/validators/oneoftype.test.ts
@@ -74,9 +74,9 @@ describe('`.oneOfType`', () => {
     expect(oneOfType([{ type: true }]).type).toBe(null)
   })
 
-  it('should validate nullable validators', () => {
+  it('should validate nullable required validators', () => {
     vi.mocked(console.warn).mockClear()
-    const mayBeNull = oneOfType([String, nullable()])
+    const mayBeNull = oneOfType([String, nullable()]).isRequired
 
     mayBeNull.def(null)
     expect(console.warn).not.toHaveBeenCalled()

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -196,7 +196,7 @@ export function validateType<T, U>(
     if (typeToCheck.type === undefined || typeToCheck.type === true) {
       return valid
     }
-    if (!typeToCheck.required && value === undefined) {
+    if (!typeToCheck.required && value == null) {
       return valid
     }
     if (isArray(typeToCheck.type)) {

--- a/packages/core/src/validators/native.ts
+++ b/packages/core/src/validators/native.ts
@@ -1,5 +1,5 @@
 import { toType, toValidableType, isInteger, warn } from '../utils'
-import { PropType } from '../types'
+import { PropOptions, PropType } from '../types'
 
 export const any = <T = any>() => toValidableType<T>('any', {})
 
@@ -70,4 +70,4 @@ export const nullable = () =>
     },
     '_vueTypes_name',
     { value: 'nullable' },
-  )
+  ) as PropOptions<null>

--- a/packages/docs/guide/validators.md
+++ b/packages/docs/guide/validators.md
@@ -321,11 +321,11 @@ props: {
 ```
 
 ::: warning
-This validator **does not come with any flag or method**. It can be used with [`oneOfType`](#oneoftype) to make a **non required** prop nullable.
+This validator **does not come with any flag or method**. It can be used with [`oneOfType`](#oneoftype) to make a **required** prop nullable.
 
 ```js
 props: {
-  stringOrNull: oneOfType([string(), nullable()])
+  stringOrNull: oneOfType([string(), nullable()]).isRequired
 }
 ```
 


### PR DESCRIPTION
1. Accepts null as valid value in validateType util
1. fix docs: `nullable()` should be used for nullable required props.



Closes https://github.com/dwightjack/vue-types/issues/383