### PR TITLE
Fix missing types in export

### DIFF
--- a/.changeset/fluffy-moose-allow.md
+++ b/.changeset/fluffy-moose-allow.md
@@ -1,0 +1,5 @@
+---
+'vue-types': patch
+---
+
+The `exports` declarations in package.json were missing the `type` subpath. See #419

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,10 +18,12 @@
   "esmodule": "dist/vue-types.modern.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/vue-types.cjs",
       "import": "./dist/vue-types.modern.js"
     },
     "./shim": {
+      "type": "./dist/shim.d.ts",
       "require": "./shim/index.cjs.js",
       "import": "./shim/index.modern.js"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
       "import": "./dist/vue-types.modern.js"
     },
     "./shim": {
-      "type": "./dist/shim.d.ts",
+      "types": "./dist/shim.d.ts",
       "require": "./shim/index.cjs.js",
       "import": "./shim/index.modern.js"
     }


### PR DESCRIPTION
Add missing types to the `exports` property

- Resolves #419 