### PR TITLE
docs: update prop validation link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ dist
 **/shim
 !**/shim/package.json
 .nuxt
+
+# VitePress
+**/.vitepress/cache

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -4,7 +4,7 @@ title: Introduction
 
 # VueTypes
 
-VueTypes is a collection of configurable [prop validators](http://vuejs.org/guide/components.html#Props) for Vue.js, inspired by React `prop-types`.
+VueTypes is a collection of configurable [prop validators](https://vuejs.org/guide/components/props.html#prop-validation) for Vue.js, inspired by React `prop-types`.
 
 [Try it now!](https://stackblitz.com/edit/vitejs-vite-83cnar?file=src/App.vue)
 


### PR DESCRIPTION
This PR updates the link for prop validators documentation.

Old one: http://vuejs.org/guide/components.html#Props (404)
New one: https://vuejs.org/guide/components/props.html#prop-validation