### PR TITLE
fix(core): fix types resolution for ESM bundlers

### DIFF
--- a/.changeset/thin-otters-reflect.md
+++ b/.changeset/thin-otters-reflect.md
@@ -1,0 +1,5 @@
+---
+'vue-types': patch
+---
+
+vue-types: expose shared types to ESM module consumers

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,9 @@
       "require": "./dist/vue-types.cjs",
       "import": "./dist/vue-types.modern.js"
     },
+    "./dist/types": {
+      "types": "./dist/types.d.ts"
+    },
     "./shim": {
       "types": "./dist/shim.d.ts",
       "require": "./shim/index.cjs.js",


### PR DESCRIPTION
Bundlers using ESM modules seems to be unable to resolve the `vue-types/dist/types` which is imported by type definitions. This PR exposes the module to consumers.

Related to https://github.com/dwightjack/vue-types/issues/474

